### PR TITLE
Fix: use a valid AI-DECLARATION.md syntax

### DIFF
--- a/AI-DECLARATION.md
+++ b/AI-DECLARATION.md
@@ -1,13 +1,13 @@
 ---
-version: 1.0
-level: moderate
+version: 0.1.2
+level: pair
 processes:
-  coding: mean (pair) you can view file by file
-  debugging: Ai tools described below
-  planning: none
-  documentation: assist 
-components:
-  you can view file by file
+  design: none
+  implementation: pair
+  testing: assist
+  documentation: assist
+  review: assist
+  deployment: none
 ---
 
 ## Notes


### PR DESCRIPTION
Hello, I am the creator and maintainer of `AI-DECLARATION.md`, and I noticed that your declaration file was failing the validation as shown below:

<img width="773" height="609" alt="Screenshot 2026-05-09 at 12 39 23 PM" src="https://github.com/user-attachments/assets/29483032-a3bd-4489-be19-219768184198" />

I run a job every day for finding new repositories that use the standard, and I appreciate you taking the initiative to honestly declare the usage of AI in your project 👏🏼 

This is a small PR to ensure the syntax is valid and complies with the standard's most recent version. You can validate it yourself at [ai-declaration.md/validate](https://ai-declaration.md/validate/).

Also, an API is coming soon. Hope this helps.

P.S. I inferred levels based on your descriptions. For a more detailed version of the standard schema, you can go to [ai-declaration.md/en/0.1.2/#schema](https://ai-declaration.md/en/0.1.2/#schema).